### PR TITLE
Fixes Redis' mocking.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ DEPENDENCIES
   json_pure (= 1.4.6)
   jtrupiano-timecop (= 0.2.1)
   mime-types (= 1.16)
-  mock_redis
+  mock_redis (= 0.4.1)
   mysql2 (= 0.2.18)
   newrelic_rpm (= 3.3.0)
   paperclip (= 2.3.1)

--- a/config/environments/cucumber.rb
+++ b/config/environments/cucumber.rb
@@ -21,8 +21,6 @@ config.action_controller.allow_forgery_protection    = false
 # ActionMailer::Base.deliveries array.
 config.action_mailer.delivery_method = :test
 
-$redis = MockRedis.new
-
 HOST = "localhost"
 AUTHORIZE_NET_API_LOGIN_ID    = ''
 AUTHORIZE_NET_TRANSACTION_KEY = ''

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,8 +21,6 @@ config.action_controller.allow_forgery_protection    = false
 # ActionMailer::Base.deliveries array.
 config.action_mailer.delivery_method = :test
 
-$redis = MockRedis.new
-
 HOST = 'localhost'
 
 AUTHORIZE_NET_API_LOGIN_ID    = ''

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,6 +21,7 @@ Webrat.configure do |config|
   config.open_error_files = false # Set to true if you want error pages to pop up in the browser
 end
 
+$redis = MockRedis.new
 
 # If you set this to false, any error raised from within your app will bubble 
 # up to your step definition and out to cucumber unless you catch it somewhere

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ require 'spec/rails'
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
+$redis = MockRedis.new
+
 Spec::Runner.configure do |config|
   # If you're not using ActiveRecord you should remove these
   # lines, delete config/database.yml and disable :active_record


### PR DESCRIPTION
We need to require mock_redis before calling MockRedis.new inside
config/environments/*.rb. This because, inside that, Bundler haven't required
our environments' gems yet.

This patch moves that to spec/spec_helper.rb and features/support/env.rb. This
fixes this problem, and also mocks Redis even if we don't run the tests through
Rake.

I also forgot to commit the Gemfile.lock. Adding this here.
