### PR TITLE
Returns all Choice or Questions' versions if requested

### DIFF
--- a/app/controllers/choices_controller.rb
+++ b/app/controllers/choices_controller.rb
@@ -96,7 +96,13 @@ class ChoicesController < InheritedResources::Base
   def show
     @question = current_user.questions.find(params[:question_id])
     @choice = @question.choices.find(params[:id])
-    show!
+    response_options = {}
+    response_options[:include] = :versions if params[:version] == 'all'
+
+    respond_to do |format|
+      format.xml { render :xml => @choice.to_xml(response_options) }
+      format.json { render :json => @choice.to_json(response_options) }
+    end
   end
 
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -23,13 +23,15 @@ class QuestionsController < InheritedResources::Base
     @question_optional_information.each do |key, value|
       optional_information << Proc.new { |options| options[:builder].tag!(key, value)}
     end
+    response_options = { :methods => [:item_count], :procs => optional_information }
+    response_options[:include] = :versions if params[:version] == "all"
 
     respond_to do |format|
       format.xml { 
-        render :xml => @question.to_xml(:methods => [:item_count], :procs => optional_information)
+        render :xml => @question.to_xml(response_options)
       }
       format.js{
-      	render :json => @question.to_json(:methods => [:item_count], :procs => optional_information)
+        render :json => @question.to_json(response_options)
       }
     end
   end

--- a/spec/controllers/choices_controller_spec.rb
+++ b/spec/controllers/choices_controller_spec.rb
@@ -125,4 +125,25 @@ describe ChoicesController do
       end
     end
   
+    describe "GET show" do
+      it "doesn't returns all versions by default" do
+        question = Factory(:question, :site => @user)
+        choice = Factory(:choice, :question => question)
+
+        get :show, :question_id => question.id, :id => choice.id, :format => "xml"
+
+        response.code.should == "200"
+        response.body.should_not have_tag("versions")
+      end
+
+      it "responds with all versions if requested" do
+        question = Factory(:question, :site => @user)
+        choice = Factory(:choice, :question => question)
+
+        get :show, :question_id => question.id, :id => choice.id, :format => "xml", :version => "all"
+
+        response.code.should == "200"
+        response.body.should have_tag("versions")
+      end
+    end
 end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -17,6 +17,7 @@ describe QuestionsController do
     assigns[:question].should == @question
     @response.body.should have_tag("question")
     @response.code.should == "200"
+    @response.body.should_not have_tag("versions")
   end
 
 
@@ -31,5 +32,13 @@ describe QuestionsController do
     @response.body.should have_tag("appearance_id")
     @response.body.should have_tag("visitor_votes")
     @response.body.should have_tag("visitor_ideas")
+  end
+
+  it "responds with all versions if requested" do
+    get :show, :id => @question.id, :format => "xml", :version => "all"
+
+    assigns[:question].should == @question
+    @response.code.should == "200"
+    @response.body.should have_tag("versions")
   end
 end


### PR DESCRIPTION
Hi,

I've added the param version, that can be sent when hitting ChoicesController#show or QuestionsController#show. If it's equal to "all", we include the "versions" association in the response.

There's no way to ask for a specific version, or to revert, but that shouldn't be hard to implement.

What do you think?

Cheers!
Vítor.
