### PR TITLE
Question redaction

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -49,9 +49,17 @@ class Question < ActiveRecord::Base
   def redact!
     self.name = REDACTED_TEXT
     self.save!
+    self.versions.each do |q_ver|
+      q_ver.name = REDACTED_TEXT
+      q_ver.save!
+    end
     choices.each do |choice|
       choice.data = REDACTED_TEXT
       choice.save!
+      choice.versions.each do |c_ver|
+        c_ver.data = REDACTED_TEXT
+        c_ver.save!
+      end
     end
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -44,6 +44,16 @@ class Question < ActiveRecord::Base
   named_scope :created_by, lambda { |id|
     {:conditions => { :local_identifier => id } }
   }
+  REDACTED_TEXT = "Redacted"
+
+  def redact!
+    self.name = REDACTED_TEXT
+    self.save!
+    choices.each do |choice|
+      choice.data = REDACTED_TEXT
+      choice.save!
+    end
+  end
 
   def create_choices_from_ideas
     if ideas && ideas.any?

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -44,7 +44,7 @@ class Question < ActiveRecord::Base
   named_scope :created_by, lambda { |id|
     {:conditions => { :local_identifier => id } }
   }
-  REDACTED_TEXT = "Redacted"
+  REDACTED_TEXT = "Redacted at request of wiki survey owner"
 
   def redact!
     self.name = REDACTED_TEXT

--- a/lib/tasks/util.rake
+++ b/lib/tasks/util.rake
@@ -10,4 +10,14 @@ namespace :util do
     u.save!
     puts "Added user #{args[:email]} with password: #{args[:password]}"
   end
+
+  desc "Redact question"
+  task :redact_question, [:question_id] => [:environment] do |t, args|
+    q = Question.find(args[:question_id])
+    puts "Confirm redaction of #{args[:question_id]}: '#{q.name}' [y/N]"
+    input = STDIN.gets.chomp
+    raise "Aborting redaction of #{args[:question_id]}" unless input == "y"
+    q.redact!
+    puts "Question #{args[:question_id]} has been redacted"
+  end
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -262,11 +262,11 @@ describe Question do
       @q.redact!
       @q.name.should == Question::REDACTED_TEXT
       latest = @q.versions.latest
-      latest.previous.name.should_not == Question::REDACTED_TEXT
+      latest.previous.name.should == Question::REDACTED_TEXT
       @q.choices.each do |choice|
         choice.data.should == Question::REDACTED_TEXT
         latest = choice.versions.latest
-        latest.previous.data.should_not == Question::REDACTED_TEXT
+        latest.previous.data.should == Question::REDACTED_TEXT
       end
     end
   end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -252,6 +252,26 @@ describe Question do
       @question.reload.prompts.count.should == 0
   end
 
+  context "redaction" do
+    before(:all) do
+      truncate_all
+      @q = Factory.create(:aoi_question)
+    end
+
+    it "should redact all choices and question text" do
+      @q.redact!
+      @q.name.should == Question::REDACTED_TEXT
+      latest = @q.versions.latest
+      latest.previous.name.should_not == Question::REDACTED_TEXT
+      @q.choices.each do |choice|
+        choice.data.should == Question::REDACTED_TEXT
+        latest = choice.versions.latest
+        latest.previous.data.should_not == Question::REDACTED_TEXT
+      end
+    end
+  end
+
+
   context "median response per session" do
     before(:all) do
       truncate_all


### PR DESCRIPTION
Fixes https://github.com/allourideas/allourideas.org/issues/75

This PR adds a method for redacting a question (`redact!`) and a rake task that will run that method if given a question_id. Redacting a question will replace the question text and all choice text with "Redacted".